### PR TITLE
Fix tab parsing of textgrid file

### DIFF
--- a/lib/textgrid.js
+++ b/lib/textgrid.js
@@ -66,7 +66,7 @@
 					fileName = "Unknown"; /* reset filename if there is are two empty lines */
 					console.log("Reset filename if there is are two empty lines");
 				}
-			} else if (line.search(/ /) !== 0) {
+			} else if (line.search(/ /) !== 0 && line.search(/\t/) !== 0) {
 				pieces = line.split(" = ");
 				if (pieces.length === 2) {
 					key = pieces[0].trim().replace(/ /g, "_");


### PR DESCRIPTION
Some TextGrid files have indents with tabs instead of spaces.  This should fix the parsing issue when there are tabs present.